### PR TITLE
feat(products): raw list of ingredients for administration

### DIFF
--- a/products/forms.py
+++ b/products/forms.py
@@ -1,5 +1,5 @@
 from django import forms
-from .models import Producto
+from .models import Producto, Ingrediente
 
 class ProductoForm(forms.ModelForm):
     class Meta:
@@ -9,3 +9,9 @@ class ProductoForm(forms.ModelForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.fields['ingredientes'].required = False
+
+
+class IngredienteForm(forms.ModelForm):
+    class Meta:
+        model = Ingrediente
+        fields = ['nombre', 'stock']

--- a/products/templates/products/ingrediente_confirm_delete.html
+++ b/products/templates/products/ingrediente_confirm_delete.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Eliminar Ingrediente</title>
+</head>
+<body>
+    <h1>Eliminar Ingrediente</h1>
+    <p>¿Seguro que deseas eliminar "{{ object.nombre }}"?</p>
+    <form method="post">
+        {% csrf_token %}
+        <button type="submit">Sí, eliminar</button>
+    </form>
+    <a href="{% url 'ingrediente_list' %}">Cancelar</a>
+</body>
+</html>

--- a/products/templates/products/ingrediente_form.html
+++ b/products/templates/products/ingrediente_form.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>{% if form.instance.pk %}Editar{% else %}Crear{% endif %} Ingrediente</title>
+</head>
+<body>
+    <h1>{% if form.instance.pk %}Editar{% else %}Crear{% endif %} Ingrediente</h1>
+    <form method="post">
+        {% csrf_token %}
+        {{ form.as_p }}
+        <button type="submit">Guardar</button>
+    </form>
+    <a href="{% url 'ingrediente_list' %}">Volver</a>
+</body>
+</html>

--- a/products/templates/products/ingrediente_list.html
+++ b/products/templates/products/ingrediente_list.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Gestión de Ingredientes</title>
+</head>
+<body>
+    <h1>Ingredientes</h1>
+    <a href="{% url 'ingrediente_create' %}">Crear ingrediente</a> |
+    <a href="{% url 'producto_list' %}">Volver a productos</a>
+
+    <table border="1" cellpadding="8" cellspacing="0">
+        <thead>
+            <tr>
+                <th>Nombre</th>
+                <th>Stock</th>
+                <th>Acciones</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for ingrediente in ingredientes %}
+            <tr>
+                <td>{{ ingrediente.nombre }}</td>
+                <td>{{ ingrediente.stock }}</td>
+                <td>
+                    <a href="{% url 'ingrediente_update' ingrediente.pk %}">Editar</a>
+                    <a href="{% url 'ingrediente_delete' ingrediente.pk %}">Eliminar</a>
+                </td>
+            </tr>
+            {% empty %}
+            <tr>
+                <td colspan="3">No hay ingredientes registrados.</td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+</body>
+</html>

--- a/products/templates/products/producto_list.html
+++ b/products/templates/products/producto_list.html
@@ -5,7 +5,8 @@
 </head>
 <body>
     <h1>Productos</h1>
-    <a href="{% url 'producto_create' %}">Crear Nuevo Producto</a>
+    <a href="{% url 'producto_create' %}">Crear Nuevo Producto</a> |
+    <a href="{% url 'ingrediente_list' %}">Gestionar Ingredientes</a>
     <ul>
         {% for producto in productos %}
         <li>

--- a/products/tests.py
+++ b/products/tests.py
@@ -1,3 +1,44 @@
+from django.contrib.auth.models import User
 from django.test import TestCase
+from django.urls import reverse
 
-# Create your tests here.
+from .models import Ingrediente
+
+
+class IngredienteCrudTests(TestCase):
+	def setUp(self):
+		self.admin_user = User.objects.create_user(username='admin', password='1234', is_staff=True)
+		self.normal_user = User.objects.create_user(username='normal', password='1234')
+		self.ingrediente = Ingrediente.objects.create(nombre='Tomate', stock=20)
+
+	def test_admin_puede_crear_ingrediente(self):
+		self.client.force_login(self.admin_user)
+		response = self.client.post(reverse('ingrediente_create'), {'nombre': 'Queso', 'stock': 15})
+
+		self.assertEqual(response.status_code, 302)
+		self.assertTrue(Ingrediente.objects.filter(nombre='Queso', stock=15).exists())
+
+	def test_admin_puede_actualizar_ingrediente(self):
+		self.client.force_login(self.admin_user)
+		response = self.client.post(
+			reverse('ingrediente_update', kwargs={'pk': self.ingrediente.pk}),
+			{'nombre': 'Tomate Cherry', 'stock': 10},
+		)
+
+		self.assertEqual(response.status_code, 302)
+		self.ingrediente.refresh_from_db()
+		self.assertEqual(self.ingrediente.nombre, 'Tomate Cherry')
+		self.assertEqual(self.ingrediente.stock, 10)
+
+	def test_admin_puede_eliminar_ingrediente(self):
+		self.client.force_login(self.admin_user)
+		response = self.client.post(reverse('ingrediente_delete', kwargs={'pk': self.ingrediente.pk}))
+
+		self.assertEqual(response.status_code, 302)
+		self.assertFalse(Ingrediente.objects.filter(pk=self.ingrediente.pk).exists())
+
+	def test_usuario_no_admin_no_puede_acceder_crud(self):
+		self.client.force_login(self.normal_user)
+		response = self.client.get(reverse('ingrediente_list'))
+
+		self.assertEqual(response.status_code, 302)

--- a/products/urls.py
+++ b/products/urls.py
@@ -1,9 +1,22 @@
 from django.urls import path
-from .views import ProductoListView, ProductoCreateView, ProductoUpdateView, ProductoDeleteView
+from .views import (
+    ProductoListView,
+    ProductoCreateView,
+    ProductoUpdateView,
+    ProductoDeleteView,
+    IngredienteListView,
+    IngredienteCreateView,
+    IngredienteUpdateView,
+    IngredienteDeleteView,
+)
 
 urlpatterns = [
     path('', ProductoListView.as_view(), name='producto_list'),
     path('create/', ProductoCreateView.as_view(), name='producto_create'),
     path('<int:pk>/update/', ProductoUpdateView.as_view(), name='producto_update'),
     path('<int:pk>/delete/', ProductoDeleteView.as_view(), name='producto_delete'),
+    path('ingredientes/', IngredienteListView.as_view(), name='ingrediente_list'),
+    path('ingredientes/create/', IngredienteCreateView.as_view(), name='ingrediente_create'),
+    path('ingredientes/<int:pk>/update/', IngredienteUpdateView.as_view(), name='ingrediente_update'),
+    path('ingredientes/<int:pk>/delete/', IngredienteDeleteView.as_view(), name='ingrediente_delete'),
 ]

--- a/products/views.py
+++ b/products/views.py
@@ -4,7 +4,7 @@ from django.utils.decorators import method_decorator
 from django.views.generic import ListView, CreateView, UpdateView, DeleteView
 from django.urls import reverse_lazy
 from .models import Producto, Categoria, Ingrediente
-from .forms import ProductoForm
+from .forms import ProductoForm, IngredienteForm
 
 def is_admin(user):
     return user.is_staff
@@ -38,3 +38,37 @@ class ProductoDeleteView(DeleteView):
     model = Producto
     template_name = 'products/producto_confirm_delete.html'
     success_url = reverse_lazy('producto_list')
+
+
+@method_decorator(login_required, name='dispatch')
+@method_decorator(user_passes_test(is_admin), name='dispatch')
+class IngredienteListView(ListView):
+    model = Ingrediente
+    template_name = 'products/ingrediente_list.html'
+    context_object_name = 'ingredientes'
+
+
+@method_decorator(login_required, name='dispatch')
+@method_decorator(user_passes_test(is_admin), name='dispatch')
+class IngredienteCreateView(CreateView):
+    model = Ingrediente
+    form_class = IngredienteForm
+    template_name = 'products/ingrediente_form.html'
+    success_url = reverse_lazy('ingrediente_list')
+
+
+@method_decorator(login_required, name='dispatch')
+@method_decorator(user_passes_test(is_admin), name='dispatch')
+class IngredienteUpdateView(UpdateView):
+    model = Ingrediente
+    form_class = IngredienteForm
+    template_name = 'products/ingrediente_form.html'
+    success_url = reverse_lazy('ingrediente_list')
+
+
+@method_decorator(login_required, name='dispatch')
+@method_decorator(user_passes_test(is_admin), name='dispatch')
+class IngredienteDeleteView(DeleteView):
+    model = Ingrediente
+    template_name = 'products/ingrediente_confirm_delete.html'
+    success_url = reverse_lazy('ingrediente_list')


### PR DESCRIPTION
## User Story
If an administrator accesses the inventory management module, the Restin POS System should provide the administrator with the ability to create, update, delete, and maintain ingredient records.

## Implemented Changes
- New `IngredientForm` form with name and stock fields
- 4 new CRUD views protected with is_staff (list, create, edit, delete)
- 4 new paths under /products/ingredients/
- 3 new HTML templates for ingredient management
- "Manage Ingredients" link on the products screen

## Automated Tests
- Admin can create a new ingredient 
- Admin can update name and stock 
- Admin can delete an ingredient 
- Users without permissions are redirected (access denied) 